### PR TITLE
fix NULL pointer access issue

### DIFF
--- a/struct2json/inc/s2j.h
+++ b/struct2json/inc/s2j.h
@@ -38,7 +38,7 @@ extern "C" {
 #endif
 
 /* struct2json software version number */
-#define S2J_SW_VERSION                "1.0.2"
+#define S2J_SW_VERSION                "1.0.3"
 
 /* Create JSON object */
 #define s2j_create_json_obj(json_obj) \

--- a/struct2json/src/s2j.c
+++ b/struct2json/src/s2j.c
@@ -46,7 +46,7 @@ void s2j_init(S2jHook *hook) {
         s2jHook.malloc_fn = (hook->malloc_fn) ? hook->malloc_fn : malloc;
         s2jHook.free_fn = (hook->free_fn) ? hook->free_fn : free;
     } else {
-        hook->malloc_fn = malloc;
-        hook->free_fn = free;
+        s2jHook.malloc_fn = malloc;
+        s2jHook.free_fn = free;
     }
 }


### PR DESCRIPTION
初始化时，如果hook为NULL，则导致访问NULL指针问题。